### PR TITLE
Add Vault Encryption and KV Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,31 @@ Stop the HTTP Barista, you can't order coffee anymore.
 
 <br />
 The dashboard shows that the load is dispatched among the baristas.
+
+## Vault
+
+Display Logs:
+```
+docker logs dev-vault
+```
+
+Initialize Vault:
+```
+docker exec dev-vault sh /tmp/init-vault.sh
+```
+
+Test Barista user:
+```
+docker exec -it dev-vault sh
+
+vault login -method=userpass username=barista password=b0r1st0
+export VAULT_TOKEN=...
+vault kv get secret/creds/barista
+```
+
+Place a Kafka order, Kafka Barista should show:
+```
+2021-04-04 11:33:19,318 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Order frappuccino for abc is ready
+2021-04-04 11:33:19,319 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Decrypting Credit Card Number vault:v1:e/SfOvVO8LeJyMDWKyUmg+mYvb2h44G3dlWy56SHoQ==
+2021-04-04 11:33:19,406 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Billing Credit Card 123 using s3cr3t Billing Code
+```

--- a/barista-quarkus-kafka/pom.xml
+++ b/barista-quarkus-kafka/pom.xml
@@ -51,6 +51,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-vault</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>
@@ -64,6 +68,11 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>4.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/barista-quarkus-kafka/src/main/java/me/escoffier/quarkus/coffeeshop/KafkaBarista.java
+++ b/barista-quarkus-kafka/src/main/java/me/escoffier/quarkus/coffeeshop/KafkaBarista.java
@@ -1,12 +1,15 @@
 package me.escoffier.quarkus.coffeeshop;
 
+import io.quarkus.vault.VaultTransitSecretEngine;
 import io.smallrye.reactive.messaging.annotations.Blocking;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Outgoing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.util.Random;
 
 import static me.escoffier.quarkus.coffeeshop.Names.pickAName;
@@ -17,6 +20,12 @@ public class KafkaBarista {
     private static final Logger LOGGER = LoggerFactory.getLogger("Kafka-Barista");
 
     private String name = pickAName();
+
+    @Inject
+    VaultTransitSecretEngine vaultTransitSecretEngine;
+
+    @ConfigProperty(name = "billing-code")
+    String billingCode;
 
     @Incoming("orders")
     @Outgoing("queue")
@@ -33,7 +42,13 @@ public class KafkaBarista {
             Thread.currentThread().interrupt();
         }
         LOGGER.info("Order {} for {} is ready", order.getProduct(), order.getName());
+        LOGGER.info("Decrypting Credit Card Number {}", order.getCreditCard());
+        LOGGER.info("Billing Credit Card {} using {} Billing Code", decryptCreditCard(order), billingCode);
         return new Beverage(order, name, Beverage.State.READY);
+    }
+
+    private String decryptCreditCard(Order order) {
+        return vaultTransitSecretEngine.decrypt("my-encryption-key", order.getCreditCard()).asString();
     }
 
     private Random random = new Random();

--- a/barista-quarkus-kafka/src/main/java/me/escoffier/quarkus/coffeeshop/Order.java
+++ b/barista-quarkus-kafka/src/main/java/me/escoffier/quarkus/coffeeshop/Order.java
@@ -8,6 +8,7 @@ public class Order {
     private String product;
     private String name;
     private String orderId;
+    private String creditCard;
 
     public String getProduct() {
         return product;
@@ -33,6 +34,15 @@ public class Order {
 
     public Order setOrderId(String orderId) {
         this.orderId = orderId;
+        return this;
+    }
+
+    public String getCreditCard() {
+        return creditCard;
+    }
+
+    public Order setCreditCard(String creditCard) {
+        this.creditCard = creditCard;
         return this;
     }
 }

--- a/barista-quarkus-kafka/src/test/java/me/escoffier/quarkus/coffeeshop/BaristaTest.java
+++ b/barista-quarkus-kafka/src/test/java/me/escoffier/quarkus/coffeeshop/BaristaTest.java
@@ -2,13 +2,18 @@ package me.escoffier.quarkus.coffeeshop;
 
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.vault.VaultTransitSecretEngine;
+import io.quarkus.vault.transit.ClearData;
 import io.smallrye.reactive.messaging.connectors.InMemoryConnector;
 import io.smallrye.reactive.messaging.connectors.InMemorySink;
 import io.smallrye.reactive.messaging.connectors.InMemorySource;
 import org.eclipse.microprofile.reactive.messaging.Message;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import javax.enterprise.inject.Any;
 import javax.inject.Inject;
@@ -24,6 +29,16 @@ class BaristaTest {
     @Any
     InMemoryConnector connector;
 
+    @Inject
+    VaultTransitSecretEngine vaultTransitSecretEngine;
+
+    @BeforeAll
+    public static void setup() {
+        VaultTransitSecretEngine mock = Mockito.mock(VaultTransitSecretEngine.class);
+        Mockito.when(mock.decrypt(Mockito.anyString(), Mockito.anyString())).thenReturn(new ClearData("hello"));
+        QuarkusMock.installMockForType(mock, VaultTransitSecretEngine.class);
+    }
+
     @Test
     void testProcessOrder() {
         InMemorySource<Order> orders = connector.source("orders");
@@ -33,6 +48,7 @@ class BaristaTest {
         order.setProduct("coffee");
         order.setName("Coffee lover");
         order.setOrderId("1234");
+        order.setCreditCard("vault:v1:e/SfOvVO8LeJyMDWKyUmg+mYvb2h44G3dlWy56SHoQ==");
 
         orders.send(order);
         

--- a/barista-quarkus-kafka/src/test/resources/application.properties
+++ b/barista-quarkus-kafka/src/test/resources/application.properties
@@ -12,6 +12,5 @@ mp.messaging.outgoing.queue.connector=smallrye-kafka
 mp.messaging.outgoing.queue.value.serializer=io.quarkus.kafka.client.serialization.JsonbSerializer
 
 quarkus.vault.url=http://localhost:8200
-quarkus.vault.authentication.userpass.username=barista
-quarkus.vault.authentication.userpass.password=b0r1st0
-quarkus.vault.secret-config-kv-path=creds/barista
+
+billing-code=abc

--- a/coffeeshop-service/pom.xml
+++ b/coffeeshop-service/pom.xml
@@ -58,6 +58,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-spring-di</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-vault</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/coffeeshop-service/src/main/java/me/escoffier/quarkus/coffeeshop/CoffeeShopResource.java
+++ b/coffeeshop-service/src/main/java/me/escoffier/quarkus/coffeeshop/CoffeeShopResource.java
@@ -1,5 +1,6 @@
 package me.escoffier.quarkus.coffeeshop;
 
+import io.quarkus.vault.VaultTransitSecretEngine;
 import io.smallrye.mutiny.Uni;
 import me.escoffier.quarkus.coffeeshop.http.BaristaService;
 import me.escoffier.quarkus.coffeeshop.model.Beverage;
@@ -7,17 +8,22 @@ import me.escoffier.quarkus.coffeeshop.model.Order;
 import org.eclipse.microprofile.reactive.messaging.Channel;
 import org.eclipse.microprofile.reactive.messaging.Emitter;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.inject.Inject;
 import java.time.Duration;
 import java.util.UUID;
 
 @RestController
 @RequestMapping("/")
 public class CoffeeShopResource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoffeeShopResource.class);
 
     @Autowired
     @RestClient
@@ -40,12 +46,21 @@ public class CoffeeShopResource {
     // Queue emitter (beverages)
     @Autowired @Channel("queue") Emitter<Beverage> queue;
 
+    @Inject
+    VaultTransitSecretEngine vaultTransitSecretEngine;
+
     @PostMapping("/messaging")
     public Order messaging(Order order) {
-        order = order.setOrderId(getId());
+        order = order
+                .setOrderId(getId())
+                .setCreditCard(encryptCreditCard(order));
         queue.send(Beverage.queued(order));
         orders.send(order);
         return order;
+    }
+
+    private String encryptCreditCard(Order order) {
+        return vaultTransitSecretEngine.encrypt("my-encryption-key", order.getCreditCard());
     }
 
     private String getId() {

--- a/coffeeshop-service/src/main/java/me/escoffier/quarkus/coffeeshop/model/Order.java
+++ b/coffeeshop-service/src/main/java/me/escoffier/quarkus/coffeeshop/model/Order.java
@@ -8,6 +8,7 @@ public class Order {
     private String product;
     private String name;
     private String orderId;
+    private String creditCard;
 
     public String getProduct() {
         return product;
@@ -33,6 +34,15 @@ public class Order {
 
     public Order setOrderId(String orderId) {
         this.orderId = orderId;
+        return this;
+    }
+
+    public String getCreditCard() {
+        return creditCard;
+    }
+
+    public Order setCreditCard(String creditCard) {
+        this.creditCard = creditCard;
         return this;
     }
 }

--- a/coffeeshop-service/src/main/resources/META-INF/resources/index.html
+++ b/coffeeshop-service/src/main/resources/META-INF/resources/index.html
@@ -23,6 +23,12 @@
             </div>
         </div>
         <div class="form-group">
+            <label class="col-md-2 control-label" for="creditCard">Credit Card</label>
+            <div class="col-md-6">
+                <input type="text" id="creditCard" class="form-control">
+            </div>
+        </div>
+        <div class="form-group">
             <label class="col-md-2 control-label" for="orderMethod">Order method</label>
             <div class="col-md-10">
                 <select id="orderMethod">
@@ -90,6 +96,7 @@
         const method = $("#orderMethod option:selected").val();
         const order = {
             name: $("#customerName").val(),
+            creditCard: $("#creditCard").val(),
             product: $("#product option:selected").val()
         };
         console.log("Customer name = " + order.name);

--- a/coffeeshop-service/src/main/resources/application.properties
+++ b/coffeeshop-service/src/main/resources/application.properties
@@ -22,3 +22,6 @@ mp.messaging.incoming.beverages.broadcast=true
 mp.messaging.incoming.beverages.value.deserializer=me.escoffier.quarkus.coffeeshop.codecs.BeverageDeserializer
 mp.messaging.incoming.beverages.enable.auto.commit=true
 
+quarkus.vault.url=http://localhost:8200
+quarkus.vault.authentication.userpass.username=coffeeshop
+quarkus.vault.authentication.userpass.password=c0ff33

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,3 +28,18 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+
+  vault:
+    image: vault
+    ports:
+      - 8200:8200
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: myroot
+      VAULT_ADDR: http://localhost:8200
+      VAULT_SKIP_VERIFY: "true"
+      VAULT_TOKEN: myroot
+    container_name: dev-vault
+    volumes:
+      - ./init-vault.sh:/tmp/init-vault.sh
+    cap_add:
+      - IPC_LOCK

--- a/init-vault.sh
+++ b/init-vault.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+# create secret
+vault kv put secret/creds/barista billing-code=s3cr3t
+
+# create encryption key
+vault secrets enable transit
+vault write -f transit/keys/my-encryption-key
+
+# create users
+vault auth enable userpass
+vault write auth/userpass/users/coffeeshop password=c0ff33 policies=coffeeshop-policy
+vault write auth/userpass/users/barista password=b0r1st0 policies=barista-policy
+
+# create policies
+
+cat <<EOF | vault policy write coffeeshop-policy -
+path "transit/encrypt/my-encryption-key" {
+  capabilities = [ "update" ]
+}
+EOF
+
+cat <<EOF | vault policy write barista-policy -
+path "secret/data/creds/barista" {
+  capabilities = ["read"]
+}
+path "transit/decrypt/my-encryption-key" {
+  capabilities = [ "update" ]
+}
+EOF


### PR DESCRIPTION
This adds an example for the _KV Secret Engine_ fetched from the _Vault Config Source_, and an encryption/decryption use case using the _Transit Secret Engine_.

I have added a `creditCard` field to the `Order` model.
In `coffeeshop-service` I encrypt the credit card number.
In `barista-quarkus-kafka` I decrypt the credit card number, then simulate a billing service, which would require a billing code (coming from the KV Store):
```
2021-04-04 11:33:19,318 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Order frappuccino for abc is ready
2021-04-04 11:33:19,319 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Decrypting Credit Card Number vault:v1:e/SfOvVO8LeJyMDWKyUmg+mYvb2h44G3dlWy56SHoQ==
2021-04-04 11:33:19,406 INFO  [Kafka-Barista] (vert.x-worker-thread-0) Billing Credit Card 123 using s3cr3t Billing Code
```

In the vault configuration I use:
 - the key-value secret engine to store secret `secret/creds/barista billing-code=s3cr3t`
 - the transit secret engine to store an encryption key

I have created 2 users: `coffeeshop` and `barista`
- `coffeeshop` has the right to encrypt.
- `barista` has the right to decrypt and read the billing code at path `secret/creds/barista`.

This demonstrates asymetric encryption/decryption among several microservices with least privilege principle. This shows a solution also to handle sensitive information when going from a full `http` design using TLS (encryption in transit), to an asynch approach where you need to protect data at rest also. Yet the code is not too complicated, probably fitting well into a demo.

I have described everything in the `README.md`.
I have not added the container to the docker compose, and an init script could be done to simplify vault initialization. to be discussed.

let me know what you think.
